### PR TITLE
Auto-update container image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.6
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for all Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Auto-approve Dependabot PRs
+        run: gh pr review "$PR_URL" --approve
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi9/python-39:1-99.1674497380
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
I've made a series of three changes that together will auto-update the container image:
* [use Dependabot to keep base image up to date](https://github.com/grafana-operator/grafana_plugins_init/commit/082921df332050872b88b7894bef5efba9827feb)
* [Auto-approve Dependabot PRs](https://github.com/grafana-operator/grafana_plugins_init/commit/d9eb3d1bc64d94bbf69da482fc4e926f3e930f53)
* [upgrade to ubi9 and use versioned tag for update tracking](https://github.com/grafana-operator/grafana_plugins_init/commit/f8b01d374e25a7017a35a139b75703a422ba349c)

Fixes grafana-operator/grafana_plugins_init#5